### PR TITLE
feat: update MongoDB.Driver to 2.30.0

### DIFF
--- a/DistributedLock.Mongo/DistributedLock.Mongo.csproj
+++ b/DistributedLock.Mongo/DistributedLock.Mongo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.2.0</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Authors>gritse</Authors>
     <PackageTags>lock,mongodb,mongo,distributed,distributedlock,mutex</PackageTags>
@@ -14,12 +14,12 @@
     <Copyright>gritse</Copyright>
     <Description>Exclusive distributed lock library for C#/.NET using MongoDB</Description>
     <PackageReleaseNotes>
-      * Fix: do not await in case of zero timeout
+      * MongoDB.Driver updated to 2.30.0
     </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.25.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.30.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DistributedLock.Sample/DistributedLock.Sample.csproj
+++ b/DistributedLock.Sample/DistributedLock.Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.25.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.30.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
At the moment, it is not possible to use MongoDB.Driver 2.30.0 with DistributedLock.Mongo 2.2.0 (which is locked to MongoDB.Driver 2.20.0).